### PR TITLE
Add an automated patch that fixes bmx160 CHIPID in Infineon SDK

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,7 +152,7 @@ LDLIBS=
 LINKER_SCRIPT=
 
 # Custom pre-build commands to run.
-PREBUILD=
+PREBUILD=/bin/bash fix-bmx160-chipid.sh;
 
 # Custom post-build commands to run.
 POSTBUILD=

--- a/deps/BMI160_driver.mtb
+++ b/deps/BMI160_driver.mtb
@@ -1,1 +1,1 @@
-https://github.com/BoschSensortec/BMI160_driver#bmi160_v3.9.1#$$ASSET_REPO$$/BMI160_driver/bmi160_v3.9.1
+https://github.com/BoschSensortec/BMI160_driver#bmi160_v3.9.1#$$LOCAL$$/BMI160_driver/bmi160_v3.9.1

--- a/fix-bmx160-chipid.patch
+++ b/fix-bmx160-chipid.patch
@@ -1,0 +1,12 @@
+diff --git a/libs/BMI160_driver/bmi160_v3.9.1/bmi160_defs.h b/libs/BMI160_driver/bmi160_v3.9.1/bmi160_defs.h
+--- a/libs/BMI160_driver/bmi160_v3.9.1/bmi160_defs.h
++++ b/libs/BMI160_driver/bmi160_v3.9.1/bmi160_defs.h
+@@ -357,7 +357,7 @@
+ #define BMI160_W_ACCEl_SELF_TEST_FAIL             INT8_C(2)
+ 
+ /** BMI160 unique chip identifier */
+-#define BMI160_CHIP_ID                            UINT8_C(0xD1)
++#define BMI160_CHIP_ID                            UINT8_C(0xD8)
+ 
+ /** Soft reset command */
+ #define BMI160_SOFT_RESET_CMD                     UINT8_C(0xb6)

--- a/fix-bmx160-chipid.sh
+++ b/fix-bmx160-chipid.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if grep -q "UINT8_C(0xD8)" libs/BMI160_driver/bmi160_v3.9.1/bmi160_defs.h; then
+    echo "BMX160 ChipID already fixed"
+else
+    rm -rf libs/BMI160_driver/bmi160_v3.9.1/examples
+    git apply --reject --whitespace=fix fix-bmx160-chipid.patch
+    echo "BMX160 ChipID fixed"
+fi


### PR DESCRIPTION
This PR improves the Developer Experience by integrating a patch in the project's Makefile.

Signed-off-by: Dimitar Tomov <dimi@edgeimpulse.com>